### PR TITLE
[Fix] 안드로이드 Large Heap 설정

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,8 @@
         android:label="비공식 Chzzk for Android TV"
         android:banner="@drawable/banner"
         android:name="${applicationName}"
+        android:largeHeap="true"
+        android:hardwareAccelerated="false"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
아이콘 많거나 vod 실행할 때 강제종료되는 오류가 있어서 현재 사용중인 ChromeCast HD에 adb 연결해서 실기기에서 테스트해보고, main.dart에 다음과 같은 코드를 넣어서 강제종료 오류를 확인했습니다.

``` dart
FlutterError.onError = (details) {
    FlutterError.presentError(details);
  };

  PlatformDispatcher.instance.onError = (error, stack) {
    return true;
  };
```

그 결과 vod 실행할 때 나오는 오류가 다음과 같았습니다.

``` shell
flutter Throwing OutOfMemoryError "Failed to allocate a 152 byte allocation with 11456 free bytes and 11KB until OOM, target footprint 134217728, growth limit 134217728; giving up on allocation because <1% of heap free after GC."
```

그래서 OutOfMemoryError쪽 확인해보니까 다음과 같은 해결 방법이 있었습니다.

https://github.com/flutter/flutter/issues/62118#issuecomment-1118444020

그래서 해당 방법대로 mainfast에 해당 코드를 추가하니 현재 테스트하면서 오류가 발생하지 않아 PR 올립니다.