### PR TITLE
일부 라이브가 실행 안되는 오류 픽스

### DIFF
--- a/lib/src/features/live/model/live_playback_json.dart
+++ b/lib/src/features/live/model/live_playback_json.dart
@@ -90,21 +90,24 @@ class Media with _$Media {
 class EncodingTrack with _$EncodingTrack {
   const factory EncodingTrack({
     required String encodingTrackId,
-    required String videoProfile,
-    required String audioProfile,
-    required String videoCodec,
-    required int videoBitRate,
+    required String? videoProfile,
+    required String? audioProfile,
+    required String? videoCodec,
+    required int? videoBitRate,
     required int audioBitRate,
-    required String videoFrameRate,
-    required int videoWidth,
-    required int videoHeight,
+    required String? videoFrameRate,
+    required int? videoWidth,
+    required int? videoHeight,
     required int audioSamplingRate,
     required int audioChannel,
     required bool avoidReencoding,
-    required String videoDynamicRange,
+    required String? videoDynamicRange,
     // 720p, 1080p
     required String? p2pPath,
     required String? p2pPathUrlEncoding,
+    required String? path,
+    required String? audioCodec,
+    required bool? audioOnly,
   }) = _EncodingTrack;
 
   factory EncodingTrack.fromJson(Map<String, dynamic> json) =>


### PR DESCRIPTION
#22 에서 나온 오류 확인해보니
일부 방송에서 EncodingTrack리스트에 해당 아이템이 추가되어 있습니다.

``` json
{
          "encodingTrackId": "audioOnly",
          "path": "https://livecloud.pstatic.net/chzzk/lip2_kr/cflexnmss2u0196/o4dv4hvoeemb25psgu6qq3b604awqrgmq4/hls_audioOnly_playlist.m3u8?hdnts=st=1743003817~exp=1743063227~acl=*/o4dv4hvoeemb25psgu6qq3b604awqrgmq4/*~hmac=d7b7a6e7b07e95a0e5aa89b4bc93a3ab926212f7cddcb85aa61767bda5e5dd49",
          "audioCodec": "AAC",
          "audioBitRate": 64000,
          "audioOnly": true,
          "audioSamplingRate": 48000,
          "audioChannel": 1,
          "avoidReencoding": false
        }
```
audioOnly라는 기능이 추가되면서 일부 값들이 오지 않아 parse error가 일어나서 생긴 문제로 보이네요.
시간 되실 때 확인해주시면 될 것 같습니다.