### PR TITLE
feat(tablet): Enhance UI and apply immersive mode for tablets

### DIFF
--- a/android/app/src/main/res/values-night-v31/styles.xml
+++ b/android/app/src/main/res/values-night-v31/styles.xml
@@ -9,6 +9,7 @@
         <item name="android:windowSplashScreenBackground">#191C1A</item>
         <item name="android:windowSplashScreenAnimatedIcon">@drawable/android12splash</item>
         <item name="android:windowSplashScreenIconBackgroundColor">#191C1A</item>
+        <item name="android:defaultFocusHighlightEnabled">false</item>
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.
          This theme determines the color of the Android Window while your
@@ -18,5 +19,6 @@
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
     <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
+        <item name="android:defaultFocusHighlightEnabled">false</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -9,6 +9,7 @@
         <item name="android:windowFullscreen">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+	<item name="android:defaultFocusHighlightEnabled">false</item>
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.
          This theme determines the color of the Android Window while your
@@ -18,5 +19,6 @@
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
     <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
+        <item name="android:defaultFocusHighlightEnabled">false</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values-v31/styles.xml
+++ b/android/app/src/main/res/values-v31/styles.xml
@@ -9,6 +9,7 @@
         <item name="android:windowSplashScreenBackground">#191C1A</item>
         <item name="android:windowSplashScreenAnimatedIcon">@drawable/android12splash</item>
         <item name="android:windowSplashScreenIconBackgroundColor">#191C1A</item>
+        <item name="android:defaultFocusHighlightEnabled">false</item>
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.
          This theme determines the color of the Android Window while your
@@ -18,5 +19,6 @@
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
     <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
+        <item name="android:defaultFocusHighlightEnabled">false</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -9,6 +9,7 @@
         <item name="android:windowFullscreen">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+        <item name="android:defaultFocusHighlightEnabled">false</item>
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.
          This theme determines the color of the Android Window while your
@@ -18,5 +19,6 @@
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
     <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
+        <item name="android:defaultFocusHighlightEnabled">false</item>
     </style>
 </resources>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:flutter/services.dart' show SystemChrome, SystemUiMode;
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -10,6 +12,9 @@ import 'src/utils/shared_preferences/shared_prefs.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Add Immersive Mode
+  SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
 
   // Get local database for settings
   final SharedPreferences sharedPrefs = await SharedPreferences.getInstance();

--- a/lib/src/common/constants/styles.dart
+++ b/lib/src/common/constants/styles.dart
@@ -131,5 +131,6 @@ abstract class AppTheme {
     useMaterial3: true,
     colorScheme: AppColors._colorScheme,
     fontFamily: 'Pretendard',
+    scaffoldBackgroundColor: Colors.black,
   );
 }

--- a/lib/src/features/live_stream/widgets/live_player.dart
+++ b/lib/src/features/live_stream/widgets/live_player.dart
@@ -15,6 +15,7 @@ class LivePlayer extends ConsumerWidget with LiveStreamState {
     final screenHeight = context.screenHeight;
 
     return GridView.builder(
+      padding: EdgeInsets.zero,
       addAutomaticKeepAlives: false,
       addRepaintBoundaries: false,
       addSemanticIndexes: false,


### PR DESCRIPTION
- Enables immersive sticky mode for a full-screen, distraction-free experience on non-TV tablet devices.
- Disables the default Android focus highlight (`defaultFocusHighlightEnabled`).
- Removes unnecessary padding to optimize the layout for tablet screen sizes.